### PR TITLE
use ../climate-token-driver.git for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "climate-token-driver"]
 	path = climate-token-driver
-	url = https://github.com/Chia-Network/climate-token-driver.git
+	url = ../climate-token-driver.git


### PR DESCRIPTION
This causes it to use https or ssh as per the checkout of the Climate-Wallet repository