### PR TITLE
ci: stop building on pushes to main

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -2,8 +2,6 @@ name: 📦🚀 Build & Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '**'
   pull_request:


### PR DESCRIPTION
We never use these `main` branch builds and the automation for releases means we build 3 times for each release when we really only need to build once. 